### PR TITLE
Defer to the system-wide upgrade strategy for user installs

### DIFF
--- a/recipes/user_install.rb
+++ b/recipes/user_install.rb
@@ -22,11 +22,12 @@ include_recipe 'rvm'
 install_pkg_prereqs
 
 Array(node['rvm']['user_installs']).each do |rvm_user|
-  version = rvm_user['version'] || node['rvm']['version']
   branch  = rvm_user['branch'] || node['rvm']['branch']
+  upgrade = rvm_user['upgrade'] || node['rvm']['upgrade']
+  version = rvm_user['version'] || node['rvm']['version']
 
   script_flags      = build_script_flags(version, branch)
-  upgrade_strategy  = build_upgrade_strategy(rvm_user['upgrade'])
+  upgrade_strategy  = build_upgrade_strategy(upgrade)
   installer_url     = rvm_user['installer_url'] || node['rvm']['installer_url']
   rvm_prefix        = rvm_user['home'] ||
                       "#{node['rvm']['user_home_root']}/#{rvm_user['user']}"


### PR DESCRIPTION
This is consistent with the way `branch` and `version` are used. Now in our Vagrantfile for chef-solo,

``` ruby
chef.json = {
  rvm: {
    branch: 'none', upgrade: '1.16.20', version: '1.16.20',
    user_installs: [ {
      user: 'vagrant',
      rubies: ['1.9.3-p327'],
      default_ruby: '1.9.3-p327',
    } ]
  }
}
```
