### PR TITLE
Avoid breakage when no gem version is passed

### DIFF
--- a/libraries/rvm_rubygems_package.rb
+++ b/libraries/rvm_rubygems_package.rb
@@ -147,7 +147,8 @@ class Chef
           end
 
           cmd = %{rvm #{ruby_strings.join(',')} #{rvm_do(gem_env.user)} #{gem_binary_path}}
-          cmd << %{ install #{name} -q --no-rdoc --no-ri -v "#{version}"}
+          cmd << %{ install #{name} -q --no-rdoc --no-ri}
+          cmd << %{ -v "#{version}"} unless version.to_s.empty?
           cmd << %{#{src}#{opts}}
 
           if gem_env.user


### PR DESCRIPTION
I was having this problem:

```
[2013-02-04T11:46:34+00:00] INFO: *** Chef 10.18.2 ***
[2013-02-04T11:46:34+00:00] INFO: [inet6] no default interface, picking the first ipaddress
[2013-02-04T11:46:36+00:00] INFO: Setting the run_list to ["role[zynk]", "role[app_converter]", "recipe[role_zynk::ephemeral]"] from JSON
[2013-02-04T11:46:38+00:00] INFO: Run List is [role[zynk], role[app_converter], recipe[role_zynk::ephemeral]]
[2013-02-04T11:46:38+00:00] INFO: Run List expands to [role_zynk::default, app_resourcemanager::converter, role_zynk::ephemeral]
[2013-02-04T11:46:39+00:00] INFO: Starting Chef Run for ip-10-252-1-241.sa-east-1.compute.internal
[2013-02-04T11:46:39+00:00] INFO: Running start handlers
[2013-02-04T11:46:39+00:00] INFO: Start handlers complete.
[2013-02-04T11:46:42+00:00] INFO: Loading cookbooks [apache2, app_resourcemanager, apt, bluepill, build-essential, chef-client, hostsfile, logrotate, nginx, ohai, redisio, role_zynk, rsyslog, runit, rvm, rvm_passenger, sudo, users, yum, zynk_apache2, zynk_rails, zynk_redis, zynk_rvm]
[2013-02-04T11:46:44+00:00] INFO: Storing updated cookbooks/zynk_rvm/attributes/normal.rb in the cache.
[2013-02-04T11:46:46+00:00] INFO: Processing gem_package[rvm] action install (rvm::default line 21)
[2013-02-04T11:46:47+00:00] WARN:  failed to find gem rvm (>= 0) from [http://rubygems.org/]

================================================================================
Error executing action `install` on resource 'gem_package[rvm]'
================================================================================

Mixlib::ShellOut::ShellCommandFailed
------------------------------------
Expected process to exit with [0], but received '1'
---- Begin output of /usr/local/rvm/rubies/ruby-1.9.3-p327/bin/gem install rvm -q --no-rdoc --no-ri -v "" ----
STDOUT: 
STDERR: ERROR:  While executing gem ... (ArgumentError)
    Illformed requirement [""]
---- End output of /usr/local/rvm/rubies/ruby-1.9.3-p327/bin/gem install rvm -q --no-rdoc --no-ri -v "" ----
Ran /usr/local/rvm/rubies/ruby-1.9.3-p327/bin/gem install rvm -q --no-rdoc --no-ri -v "" returned 1

Cookbook Trace:
---------------
/var/chef/cache/cookbooks/rvm/recipes/default.rb:23:in `from_file'
/var/chef/cache/cookbooks/rvm/recipes/system_install.rb:20:in `from_file'
/var/chef/cache/cookbooks/rvm/recipes/system.rb:20:in `from_file'
/var/chef/cache/cookbooks/zynk_rvm/recipes/default.rb:10:in `from_file'
/var/chef/cache/cookbooks/role_zynk/recipes/default.rb:18:in `from_file'

Resource Declaration:
---------------------
# In /var/chef/cache/cookbooks/rvm/recipes/default.rb

 21: gem_package 'rvm' do
 22:   action :nothing
 23: end.run_action(:install)
 24: 
 25: require 'rubygems'
 26: Gem.clear_paths
 27: require 'rvm'
 28: create_rvm_shell_chef_wrapper
 29: create_rvm_chef_user_environment
 30: 
 31: class Chef::Resource
 32:   # mix in #rvm_cmd_wrap helper into resources
 33:   include Chef::RVM::ShellHelpers
 34: end
 35: 

Compiled Resource:
------------------
# Declared in /var/chef/cache/cookbooks/rvm/recipes/default.rb:21:in `from_file'

gem_package("rvm") do
  provider Chef::Provider::Package::Rubygems
  action [:nothing]
  retries 0
  retry_delay 2
  package_name "rvm"
  cookbook_name "rvm"
  recipe_name "default"
  gem_binary "/usr/local/rvm/rubies/ruby-1.9.3-p327/bin/gem"
end


================================================================================
Recipe Compile Error in /var/chef/cache/cookbooks/role_zynk/recipes/default.rb
================================================================================

Mixlib::ShellOut::ShellCommandFailed
------------------------------------
gem_package[rvm] (rvm::default line 21) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '1'
---- Begin output of /usr/local/rvm/rubies/ruby-1.9.3-p327/bin/gem install rvm -q --no-rdoc --no-ri -v "" ----
STDOUT: 
STDERR: ERROR:  While executing gem ... (ArgumentError)
    Illformed requirement [""]
---- End output of /usr/local/rvm/rubies/ruby-1.9.3-p327/bin/gem install rvm -q --no-rdoc --no-ri -v "" ----
Ran /usr/local/rvm/rubies/ruby-1.9.3-p327/bin/gem install rvm -q --no-rdoc --no-ri -v "" returned 1

Cookbook Trace:
---------------
  /var/chef/cache/cookbooks/rvm/recipes/default.rb:23:in `from_file'
  /var/chef/cache/cookbooks/rvm/recipes/system_install.rb:20:in `from_file'
  /var/chef/cache/cookbooks/rvm/recipes/system.rb:20:in `from_file'
  /var/chef/cache/cookbooks/zynk_rvm/recipes/default.rb:10:in `from_file'
  /var/chef/cache/cookbooks/role_zynk/recipes/default.rb:18:in `from_file'

Relevant File Content:
----------------------
/var/chef/cache/cookbooks/rvm/recipes/default.rb:

 16:  # See the License for the specific language governing permissions and
 17:  # limitations under the License.
 18:  #
 19:  
 20:  # install rvm api gem during chef compile phase
 21:  gem_package 'rvm' do
 22:    action :nothing
 23>> end.run_action(:install)
 24:  
 25:  require 'rubygems'
 26:  Gem.clear_paths
 27:  require 'rvm'
 28:  create_rvm_shell_chef_wrapper
 29:  create_rvm_chef_user_environment
 30:  
 31:  class Chef::Resource
 32:    # mix in #rvm_cmd_wrap helper into resources

[2013-02-04T11:46:48+00:00] ERROR: Running exception handlers
[2013-02-04T11:46:48+00:00] FATAL: Saving node information to /var/chef/cache/failed-run-data.json
[2013-02-04T11:46:48+00:00] ERROR: Exception handlers complete
[2013-02-04T11:46:48+00:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
[2013-02-04T11:46:48+00:00] FATAL: Mixlib::ShellOut::ShellCommandFailed: gem_package[rvm] (rvm::default line 21) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '1'
---- Begin output of /usr/local/rvm/rubies/ruby-1.9.3-p327/bin/gem install rvm -q --no-rdoc --no-ri -v "" ----
STDOUT: 
STDERR: ERROR:  While executing gem ... (ArgumentError)
    Illformed requirement [""]
---- End output of /usr/local/rvm/rubies/ruby-1.9.3-p327/bin/gem install rvm -q --no-rdoc --no-ri -v "" ----
Ran /usr/local/rvm/rubies/ruby-1.9.3-p327/bin/gem install rvm -q --no-rdoc --no-ri -v "" returned 1
```
