### PR TITLE
rvm_shell provider accepts an environment for both user and system-wide installs

### DIFF
--- a/providers/shell.rb
+++ b/providers/shell.rb
@@ -75,14 +75,17 @@ def script_wrapper(exec_action)
   s = script new_resource.name do
     interpreter   "bash"
 
+    base_environment = {}
     if new_resource.user
       user        new_resource.user
-      if user_rvm && new_resource.environment
-        environment({ 'USER' => new_resource.user, 'HOME' => user_home }.merge(
-          new_resource.environment))
-      elsif user_rvm
-        environment({ 'USER' => new_resource.user, 'HOME' => user_home })
+      if user_rvm
+        base_environment['USER'] = new_resource.user
+        base_environment['HOME'] = user_home
       end
+    end
+
+    if new_resource.environment
+      environment(base_environment.merge(new_resource.environment))
     end
 
     code          script_code


### PR DESCRIPTION
I have a system-wide RVM installation and there times when I need to use an rvm-aware shell in a chef recipe, but in the context of a given user's environment (I need to access that user's SSH keys, other things that are found by referencing a HOME and USER environment variable).

Currently, the rvm_shell provider only allows an environment to be specified if:

1) there is a "user" specified
2) RVM was installed on a per-user basis

This patch addresses both cases:

A base environment is still applied when in an rvm-per-user context, a specified environment is still merged onto this base.

But, also -- regardless of specifying a "user" or the type of RVM installation used (system-wide vs per-user), if a specified environment is found, we'll use it.

This would fix issue #69
