### PR TITLE
Update rvm gem to 1.11.3.8

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,7 +20,7 @@
 # install rvm api gem during chef compile phase
 chef_gem 'rvm' do
   action :install
-  version '>= 1.11.3.6'
+  version '>= 1.11.3.8'
 end
 require 'rvm'
 


### PR DESCRIPTION
With changes in 1.11.3.8 ( https://github.com/wayneeseguin/rvm-gem/pull/13), rvm::user will be able to work with latest stable version of rvm (1.20.12)

Should fix #199, #160, #159
