### PR TITLE
Provide LWRP for creating RVM Aliases

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gem 'rake'
 gem 'foodcritic'
 gem 'minitest'
+gem 'mixlib-shellout'
 
 # allow CI to override the version of Chef for matrix testing
 gem 'chef', (ENV['CHEF_VERSION'] || '>= 0.10.10')

--- a/providers/alias.rb
+++ b/providers/alias.rb
@@ -1,0 +1,40 @@
+def whyrun_supported?
+  false
+end
+
+action :create do
+  alias_name = new_resource.alias_name
+  version = new_resource.version
+
+  unless alias_exists(alias_name, version)
+    Chef::Log.info(">> adding rvm alias #{alias_name} => #{version}")
+    rvm_shell "Create RVM Alias #{alias_name}" do
+      code    %(rvm alias create #{alias_name} #{version})
+      path    ["#{node['rvm']['root_path']}/bin"]
+    end
+
+    new_resource.updated_by_last_action(true)
+  end
+end
+
+action :delete do
+  alias_name = new_resource.alias_name
+  version = new_resource.version
+
+  if alias_exists(alias_name, version)
+    Chef::Log.info(">> removing rvm alias #{alias_name} => #{version}")
+    rvm_shell "Delete RVM Alias #{alias_name}" do
+      code    %(rvm alias delete #{alias_name} #{version})
+      path    ["#{node['rvm']['root_path']}/bin"]
+    end
+
+    new_resource.updated_by_last_action(true)
+  end
+end
+
+def alias_exists(alias_name, version)
+  command = Mixlib::ShellOut.new("rvm alias show #{alias_name} | grep '^#{version}'")
+  command.run_command
+
+  command.exitstatus == 0
+end

--- a/resources/alias.rb
+++ b/resources/alias.rb
@@ -1,0 +1,9 @@
+actions :create, :delete
+
+attribute :alias_name, :kind_of => String, :name_attribute => true
+attribute :version, :kind_of => String
+
+def initialize(*args)
+  super
+  @action = :create
+end


### PR DESCRIPTION
I think the alias_exists function could probably be better written
without using Mixlib::Shellout. Please provide some feedback on this
commit as I would like to see an alias provider included in this
cookbook.
