### PR TITLE
Propagate environment param in rvm_shell

### DIFF
--- a/providers/shell.rb
+++ b/providers/shell.rb
@@ -75,14 +75,15 @@ def script_wrapper(exec_action)
   s = script new_resource.name do
     interpreter   "bash"
 
+    current_environment = new_resource.environment
     if new_resource.user
-      user        new_resource.user
-      if user_rvm && new_resource.environment
-        environment({ 'USER' => new_resource.user, 'HOME' => user_home }.merge(
-          new_resource.environment))
-      elsif user_rvm
-        environment({ 'USER' => new_resource.user, 'HOME' => user_home })
+      user new_resource.user
+      if user_rvm
+        current_environment = { 'USER' => new_resource.user, 'HOME' => user_home }.merge(current_environment || {})
       end
+    end
+    if current_environment
+      environment current_environment
     end
 
     code          script_code


### PR DESCRIPTION
rvm_shell used passed `environment` param only when rvm was installed under the user. Now it is set when environment is passed in rvm_shell AND when environment is nil, but we need to set USER and HOME env variables.
