### PR TITLE
Fix package clone warnings

### DIFF
--- a/libraries/chef_rvm_recipe_helpers.rb
+++ b/libraries/chef_rvm_recipe_helpers.rb
@@ -42,7 +42,8 @@ class Chef
         return if mac_with_no_homebrew
 
         node['rvm']['install_pkgs'].each do |pkg|
-          p = package pkg do
+          p = package "rvm-install-pkgs-#{pkg}" do
+            package_name pkg
             # excute in compile phase if gem_package recipe is requested
             if install_now
               action :nothing

--- a/providers/ruby.rb
+++ b/providers/ruby.rb
@@ -171,7 +171,8 @@ def install_ruby_dependencies(rubie)
   end
 
   pkgs.each do |pkg|
-    package pkg do
+    package "install-ruby-dependency-#{pkg}" do
+      package_name pkg
       action :nothing
     end.run_action(:install)
   end


### PR DESCRIPTION
When running rvm recipes after build-essential, you tend to get a bunch
of clone warnings as the packages overlap. Since these installs are
happening ad compile/no compile times in code and can't really pull in
build-essential, make the names unique to weed out some of the
extraneous output.
