### PR TITLE
rvm_gem options don't work, should allow a string argument like gem_package

### DIFF
--- a/resources/gem.rb
+++ b/resources/gem.rb
@@ -26,7 +26,7 @@ attribute :version,       :kind_of => String
 attribute :ruby_string,   :kind_of => String, :default => "default"
 attribute :response_file, :kind_of => String
 attribute :source,        :kind_of => String
-attribute :options,       :kind_of => Hash
+attribute :options,       :kind_of => [String,Hash]
 attribute :gem_binary,    :kind_of => String
 attribute :user,          :kind_of => String
 


### PR DESCRIPTION
I wanted to install a gem without dependencies like so:

``` ruby
rvm_gem "foo" do
  version "0.7.0"
  options "--ignore-dependencies"
end
```

but it would not work, I tried using a hash like `options(:ignore_dependencies=>true)` but this just got mangled into `ignoredependenciestrue` in the generated command.

Chef's own `gem_package` task supports either a String or a Hash, (http://docs.opscode.com/resource_gem_package.html) so I changed the allowed types for `rvm_gem`'s `options` attribute.  Now they can be either a String or a Hash, and testing with a string (as above) it is now working for me.
