### PR TITLE
handle groups more elegantly (rvm::system)

### DIFF
--- a/recipes/system.rb
+++ b/recipes/system.rb
@@ -32,6 +32,7 @@ end
 # add users to rvm group
 group 'rvm' do
   members node['rvm']['group_users']
+  action [:create, :modify]
 
   only_if { node['rvm']['group_users'].any? }
 end


### PR DESCRIPTION
I noticed if I used rvm::vagrant in my run list, then any users I setup in my chef recipe don't get added. Adding modify to this action fixes that problem. (:create is default)
