### PR TITLE
Pass rubygems_version to 'rvm install'

### DIFF
--- a/providers/ruby.rb
+++ b/providers/ruby.rb
@@ -41,6 +41,7 @@ action :install do
     install_start   = Time.now
     install_options = {:rvm_by_path => true}
     install_options[:patch] = new_resource.patch if new_resource.patch
+    install_options[:rubygems_version] = new_resource.rubygems_version if new_resource.rubygems_version
 
     install_ruby_dependencies @rubie
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,7 +20,7 @@
 # install rvm api gem during chef compile phase
 chef_gem 'rvm' do
   action :install
-  version '>= 1.11.3.6'
+  version '>= 1.11.3.9'
 end
 require 'rvm'
 


### PR DESCRIPTION
See: https://github.com/wayneeseguin/rvm-gem/pull/14

This pull request paired with the above makes it so a specified :rubygems_version for a rvm_ruby is used to install that ruby. Locking in an rvm version with `node[:rvm][:version]` will otherwise result in eventual convergence errors during ruby installs due to missing rubygem archive checksums.

e.g. the following error showed with rvm version 1.22.13 and ruby-1.8.7-p374:

> There is no checksum for 'http://production.cf.rubygems.org/rubygems/rubygems-2.0.14.tgz' or 'rubygems-2.0.14.tgz', it's not possible to validate it.
> This could be because your RVM install's list of versions is out of date. You may want to
> update your list of rubies by running 'rvm get stable' and try again.
> If that does not resolve the issue and you wish to continue with unverified download
> add '--verify-downloads 1' after the command.
> 
> There has been an error while trying to fetch rubygems. 
> Halting the installation.

With the patches, using something like the following will work now and 6 months from now:

```
node.default[:rvm][:version] = '1.22.13'
….
node.default['rvm']['rubies'] << {
  'version' =>'ruby-1.8.7-p374',
  'rubygems_version' => '1.8.23'
}
```
