### PR TITLE
Add sqlite Ruby pkg dependency for RHEL family.

### DIFF
--- a/providers/ruby.rb
+++ b/providers/ruby.rb
@@ -145,7 +145,7 @@ def install_ruby_dependencies(rubie)
         pkgs += %w{ git subversion autoconf } if rubie =~ /^ruby-head$/
       when "centos","redhat","fedora","scientific","amazon"
         pkgs = %w{ gcc-c++ patch readline readline-devel zlib zlib-devel
-                   libyaml-devel libffi-devel openssl-devel
+                   libyaml-devel libffi-devel openssl-devel sqlite-devel
                    make bzip2 autoconf automake libtool bison
                    libxml2 libxml2-devel libxslt libxslt-devel }
         pkgs += %w{ git subversion autoconf } if rubie =~ /^ruby-head$/


### PR DESCRIPTION
For parity with other distros and making sqlite3 available out of the box.
