### PR TITLE
Feature/fix user gem attr

### DIFF
--- a/libraries/rvm_rubygems_package.rb
+++ b/libraries/rvm_rubygems_package.rb
@@ -150,15 +150,17 @@ class Chef
           cmd << %{ install #{name} -q --no-rdoc --no-ri -v "#{version}"}
           cmd << %{#{src}#{opts}}
 
+          run_user = 'root'
           if gem_env.user
             user_dir    = Etc.getpwnam(gem_env.user).dir
             environment = { 'USER' => gem_env.user, 'HOME' => user_dir }
+            run_user = gem_env.user
           else
             user_dir    = nil
             environment = nil
           end
 
-          shell_out!(rvm_wrap_cmd(cmd, user_dir), :env => environment)
+          shell_out!(rvm_wrap_cmd(cmd, user_dir), :user => run_user, :env => environment)
         end
 
         def remove_package(name, version)

--- a/libraries/rvm_rubygems_package.rb
+++ b/libraries/rvm_rubygems_package.rb
@@ -150,17 +150,19 @@ class Chef
           cmd << %{ install #{name} -q --no-rdoc --no-ri -v "#{version}"}
           cmd << %{#{src}#{opts}}
 
-          run_user = 'root'
+          shell_out_opt = {}
           if gem_env.user
             user_dir    = Etc.getpwnam(gem_env.user).dir
             environment = { 'USER' => gem_env.user, 'HOME' => user_dir }
-            run_user = gem_env.user
+            shell_out_opt[:user] = gem_env.user
+            shell_out_opt[:env] = environment
           else
             user_dir    = nil
             environment = nil
+            shell_out_opt[:env] = environment
           end
 
-          shell_out!(rvm_wrap_cmd(cmd, user_dir), :user => run_user, :env => environment)
+          shell_out!(rvm_wrap_cmd(cmd, user_dir), shell_out_opt)
         end
 
         def remove_package(name, version)


### PR DESCRIPTION
If user uses user_installs::gems attribute, target gems are installed as root user.
Therefore user can't delete those gems as user permission.

I fixed this problem.
