### PR TITLE
Set explicitly environment vars and other minor changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,18 @@ If using the `vagrant` recipe, this sets the path to the package-installed
 
 The default is `"/opt/ruby/bin/chef-solo"`.
 
+### <a name="attributes-gpg_keyserver"></a> gpg_keyserver
+
+The keyserver from which to download the public GPG key for RVM installer verification.
+
+The default is `"keys.gnupg.net"`. 
+
+Other valid servers that can be used:
+
+- `pgp.mit.edu`
+- `keyserver.ubuntu.com`
+- `subkeys.pgp.net`
+
 ## <a name="lwrps"></a> Resources and Providers
 
 ### <a name="lwrps-rvmruby"></a> rvm_ruby

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -55,6 +55,7 @@ default['rvm']['group_users']   = []
 
 # GPG key for rvm verification
 default['rvm']['gpg_key']       = 'D39DC0E3'
+default['rvm']['gpg_keyserver']       = 'hkp://pgp.mit.edu'
 
 case platform
 when "redhat","centos","fedora","scientific","amazon"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -55,7 +55,7 @@ default['rvm']['group_users']   = []
 
 # GPG key for rvm verification
 default['rvm']['gpg_key']       = 'D39DC0E3'
-default['rvm']['gpg_keyserver']       = 'hkp://pgp.mit.edu'
+default['rvm']['gpg_keyserver'] = 'hkp://keys.gnupg.net'
 
 case platform
 when "redhat","centos","fedora","scientific","amazon"

--- a/recipes/system_install.rb
+++ b/recipes/system_install.rb
@@ -30,10 +30,13 @@ if node['rvm']['group_id'] != 'default'
   g.run_action(:create)
 end
 
+
 execute 'Adding gpg key' do
-  command "`which gpg2 || which gpg` --keyserver hkp://keys.gnupg.net --recv-keys #{node['rvm']['gpg_key']}"
+  environment ({"HOME" => "/root", "USER" => "root"})
+  command "`which gpg2 || which gpg` --keyserver hkp://pgp.mit.edu --recv-keys #{node['rvm']['gpg_key']}"
   only_if 'which gpg2 || which gpg'
   not_if { node['rvm']['gpg_key'].empty? }
+  not_if "`which gpg2 || which gpg` --list-keys | fgrep #{node['rvm']['gpg_key']}"
 end
 
 rvm_installation("root")

--- a/recipes/system_install.rb
+++ b/recipes/system_install.rb
@@ -33,7 +33,7 @@ end
 
 execute 'Adding gpg key' do
   environment ({"HOME" => "/root", "USER" => "root"})
-  command "`which gpg2 || which gpg` --keyserver hkp://pgp.mit.edu --recv-keys #{node['rvm']['gpg_key']}"
+  command "`which gpg2 || which gpg` --keyserver #{node['rvm']['gpg_keyserver']} --recv-keys #{node['rvm']['gpg_key']}"
   only_if 'which gpg2 || which gpg'
   not_if { node['rvm']['gpg_key'].empty? }
   not_if "`which gpg2 || which gpg` --list-keys | fgrep #{node['rvm']['gpg_key']}"


### PR DESCRIPTION
Set explicitly HOME environment var because in sudo executions, fails back to user home instead of root
Change gpg keyserver to pgp.mit.edu because is more reliable
Add 'not_if' guard to avoid download key if it was already in ring
