### PR TITLE
Install ruby by default for system recipe

### DIFF
--- a/recipes/system.rb
+++ b/recipes/system.rb
@@ -19,15 +19,10 @@
 
 include_recipe "rvm::system_install"
 
-perform_install_rubies  = node['rvm']['install_rubies'] == true ||
-                  node['rvm']['install_rubies'] == "true"
-
-if perform_install_rubies
-  install_rubies  :rubies => node['rvm']['rubies'],
-                  :default_ruby => node['rvm']['default_ruby'],
-                  :global_gems => node['rvm']['global_gems'],
-                  :gems => node['rvm']['gems']
-end
+install_rubies :rubies => node['rvm']['rubies'],
+               :default_ruby => node['rvm']['default_ruby'],
+               :global_gems => node['rvm']['global_gems'],
+               :gems => node['rvm']['gems']
 
 # add users to rvm group
 group 'rvm' do

--- a/recipes/system_install.rb
+++ b/recipes/system_install.rb
@@ -34,7 +34,7 @@ key_server = node['rvm']['gpg']['keyserver'] || "hkp://keys.gnupg.net"
 home_dir = "#{node['rvm']['gpg']['homedir'] || '~'}/.gnupg"
 
 execute 'Adding gpg key' do
-  command "`which gpg2 || which gpg` --keyserver #{key_server} --homedir #{home_dir} --recv-keys #{node['rvm']['gpg_key']}"
+  command "`which gpg2 || which gpg` --list-keys #{node['rvm']['gpg_key']} || `which gpg2 || which gpg` --keyserver #{key_server} --homedir #{home_dir} --recv-keys #{node['rvm']['gpg_key']}"
   only_if 'which gpg2 || which gpg'
   not_if { node['rvm']['gpg_key'].empty? }
 end


### PR DESCRIPTION
- As mentioned in the README, recipe[rvm::system] will install rvm and ruby by default.

Apparently its not, as there is a check here:

```
perform_install_rubies  = node['rvm']['install_rubies'] == true ||
                  node['rvm']['install_rubies'] == "true"
```
