### PR TITLE
Fix 'already initialized constant' warnings

### DIFF
--- a/libraries/rvm_chef_user_environment.rb
+++ b/libraries/rvm_chef_user_environment.rb
@@ -49,6 +49,7 @@ def create_rvm_chef_user_environment
       @@root_rvm_path = path
     end
   end
+  ::RVM.send(:remove_const, 'ChefUserEnvironment') if ::RVM.const_defined?('ChefUserEnvironment') # Remove constant if it's already defined to avoid Ruby interpreter warning
   ::RVM.const_set('ChefUserEnvironment', klass)
 
   ::RVM::ChefUserEnvironment.root_rvm_path = node['rvm']['root_path']

--- a/libraries/rvm_shell_chef_wrapper.rb
+++ b/libraries/rvm_shell_chef_wrapper.rb
@@ -93,6 +93,7 @@ def create_rvm_shell_chef_wrapper
       end
     end
   end
+  ::RVM::Shell.send(:remove_const, 'ChefWrapper') if ::RVM::Shell.const_defined?('ChefWrapper') # Remove constant if it's already defined to avoid Ruby interpreter warning
   ::RVM::Shell.const_set('ChefWrapper', klass)
 
   ::RVM::Shell.default_wrapper = ::RVM::Shell::ChefWrapper


### PR DESCRIPTION
When running ChefSpec with chef-rvm there are warnings, which clutter spec output like this:

```
/var/folders/g8/sr9f0__x5nn7b1n_lvhjncl40000gn/T/d20150211-41323-m891oo/cookbooks/rvm/libraries/rvm_shell_chef_wrapper.rb:96: warning: already initialized constant RVM::Shell::ChefWrapper
/var/folders/g8/sr9f0__x5nn7b1n_lvhjncl40000gn/T/d20150211-41323-m891oo/cookbooks/rvm/libraries/rvm_shell_chef_wrapper.rb:96: warning: previous definition of ChefWrapper was here

/var/folders/g8/sr9f0__x5nn7b1n_lvhjncl40000gn/T/d20150211-41323-m891oo/cookbooks/rvm/libraries/rvm_chef_user_environment.rb:52: warning: already initialized constant RVM::ChefUserEnvironment
/var/folders/g8/sr9f0__x5nn7b1n_lvhjncl40000gn/T/d20150211-41323-m891oo/cookbooks/rvm/libraries/rvm_chef_user_environment.rb:52: warning: previous definition of ChefUserEnvironment was here

/var/folders/g8/sr9f0__x5nn7b1n_lvhjncl40000gn/T/d20150211-41323-m891oo/cookbooks/rvm/libraries/rvm_chef_user_environment.rb:49: warning: class variable access from toplevel
```

First two warning are caused by redefining constants `::RVM::Shell::ChefWrapper` and `::RVM::ChefUserEnvironment` when functions `create_rvm_shell_chef_wrapper` and `create_rvm_chef_user_environment` are called multiple times during test runs.

This PR fix first two warnings by undefining constants just before their redefinition.
Third warning is fixed by https://github.com/fnichol/chef-rvm/pull/212, please reconsider its merging too.
