### PR TITLE
Move GPG defaults to attributes file

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -56,6 +56,9 @@ default['rvm']['group_users']   = []
 # GPG key for rvm verification
 default['rvm']['gpg_key']       = 'D39DC0E3'
 
+default['rvm']['gpg']['keyserver'] = 'hkp://keys.gnupg.net'
+default['rvm']['gpg']['homedir']   = '~'
+
 case platform
 when "redhat","centos","fedora","scientific","amazon"
   node.set['rvm']['install_pkgs']   = %w{sed grep tar gzip bzip2 bash curl git}

--- a/recipes/system_install.rb
+++ b/recipes/system_install.rb
@@ -30,8 +30,8 @@ if node['rvm']['group_id'] != 'default'
   g.run_action(:create)
 end
 
-key_server = node['rvm']['gpg']['keyserver'] || "hkp://keys.gnupg.net"
-home_dir = "#{node['rvm']['gpg']['homedir'] || '~'}/.gnupg"
+key_server = node['rvm']['gpg']['keyserver']
+home_dir = "#{node['rvm']['gpg']['homedir']}/.gnupg"
 
 execute 'Adding gpg key' do
   command "`which gpg2 || which gpg` --keyserver #{key_server} --homedir #{home_dir} --recv-keys #{node['rvm']['gpg_key']}"


### PR DESCRIPTION
It's better to define these as defaults, else they have the possibility of causing an error when running the rvm::system recipe without any configuration.
