### PR TITLE
Fixes #306 (RVM system install)

### DIFF
--- a/recipes/system_install.rb
+++ b/recipes/system_install.rb
@@ -31,7 +31,7 @@ if node['rvm']['group_id'] != 'default'
 end
 
 key_server = node['rvm']['gpg']['keyserver'] || "hkp://keys.gnupg.net"
-home_dir = "#{node['rvm']['gpg']['homedir'] || '~'}/.gnupg"
+home_dir = "#{node['rvm']['gpg']['homedir'] || '/root'}/.gnupg"
 
 execute 'Adding gpg key' do
   command "`which gpg2 || which gpg` --keyserver #{key_server} --homedir #{home_dir} --recv-keys #{node['rvm']['gpg_key']}"

--- a/recipes/system_install.rb
+++ b/recipes/system_install.rb
@@ -37,6 +37,7 @@ execute 'Adding gpg key' do
   command "`which gpg2 || which gpg` --keyserver #{key_server} --homedir #{home_dir} --recv-keys #{node['rvm']['gpg_key']}"
   only_if 'which gpg2 || which gpg'
   not_if { node['rvm']['gpg_key'].empty? }
+  user "root"
 end
 
 rvm_installation("root")


### PR DESCRIPTION
This fixes issue #306 on Ubuntu 14.04. 

`system_install` installs rvm as root but sets gpg up as current user, which causes gpg verification to fail. 
