### PR TITLE
Updated fixes #306 (RVM system install)

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -56,7 +56,6 @@ default['rvm']['group_users']   = []
 # GPG key for rvm verification
 default['rvm']['gpg_key']       = 'D39DC0E3'
 default['rvm']['gpg_keyserver'] = 'hkp://keys.gnupg.net'
-default['rvm']['gpg_homedir']   = '~'
 
 case platform
 when "redhat","centos","fedora","scientific","amazon"

--- a/recipes/system_install.rb
+++ b/recipes/system_install.rb
@@ -31,12 +31,13 @@ if node['rvm']['group_id'] != 'default'
 end
 
 key_server = node['rvm']['gpg_keyserver']
-home_dir = "#{node['rvm']['gpg_homedir']}/.gnupg"
+home_dir = "#{Etc.getpwnam('root').dir}/.gnupg"
 
 execute 'Adding gpg key' do
   command "`which gpg2 || which gpg` --keyserver #{key_server} --homedir #{home_dir} --recv-keys #{node['rvm']['gpg_key']}"
+  user 'root'
   only_if 'which gpg2 || which gpg'
   not_if { node['rvm']['gpg_key'].empty? }
 end
 
-rvm_installation("root")
+rvm_installation('root')


### PR DESCRIPTION
Not sure if it's possible to update pull requests so I created a new one in place of #321. 
This is supposed to fix #306. Tested on Ubuntu 14.04 with my existing configuration and with bare cookbook.

I removed `node['rvm']['gpg']['homedir']` attribute as it's only used in one place and I believe the value depends on the installation type, not user's settings. I think it needs to be set to `Etc.getpwnam(node['rvm']['user']).dir` for user install and to `Etc.getpwnam('root').dir` for system install.

Might be a good idea to test it on other systems.
