### PR TITLE
Force action does not install and as a result doesn't force anything.

### DIFF
--- a/libraries/provider_rvm_installation.rb
+++ b/libraries/provider_rvm_installation.rb
@@ -53,6 +53,7 @@ class Chef
 
       def action_force
         converge_rvmrc
+        converge_install
       end
 
       def converge_rvmrc


### PR DESCRIPTION
Adding converge_install step to force action.
