### PR TITLE
Chef fails to evaluate attributes which don't exist

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -53,8 +53,12 @@ default['rvm']['root_path']     = "/usr/local/rvm"
 default['rvm']['group_id']      = 'default'
 default['rvm']['group_users']   = []
 
+
 # GPG key for rvm verification
 default['rvm']['gpg_key']       = 'D39DC0E3'
+default['rvm']['gpg']['keyserver'] = 'hkp://keys.gnupg.net'
+default['rvm']['gpg']['homedir'] = '~/.gnup'
+'~'}/.gnup
 
 case platform
 when "redhat","centos","fedora","scientific","amazon"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -57,7 +57,7 @@ default['rvm']['group_users']   = []
 # GPG key for rvm verification
 default['rvm']['gpg_key']       = 'D39DC0E3'
 default['rvm']['gpg']['keyserver'] = 'hkp://keys.gnupg.net'
-default['rvm']['gpg']['homedir'] = '~/.gnup'
+default['rvm']['gpg']['homedir'] = '~/'
 
 case platform
 when "redhat","centos","fedora","scientific","amazon"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -58,7 +58,6 @@ default['rvm']['group_users']   = []
 default['rvm']['gpg_key']       = 'D39DC0E3'
 default['rvm']['gpg']['keyserver'] = 'hkp://keys.gnupg.net'
 default['rvm']['gpg']['homedir'] = '~/.gnup'
-'~'}/.gnup
 
 case platform
 when "redhat","centos","fedora","scientific","amazon"


### PR DESCRIPTION
The following is causing chef to fail due to `node['rvm']['gpg']['keyserver']` and `node['rvm']['gpg']['homedir']` not being defined

```
key_server = node['rvm']['gpg']['keyserver'] || "hkp://keys.gnupg.net"
home_dir = "#{node['rvm']['gpg']['homedir'] || '~'}/.gnupg"
```

```
var/chef/cache/cookbooks/rvm/libraries/rvm_chef_user_environment.rb:49: warning: class variable access from toplevel

  ================================================================================
  Recipe Compile Error in /var/chef/cache/cookbooks/rvm/recipes/system.rb
  ================================================================================

  NoMethodError
  -------------
  undefined method `[]' for nil:NilClass

  Cookbook Trace:
  ---------------
    /var/chef/cache/cookbooks/rvm/recipes/system_install.rb:33:in `from_file'
    /var/chef/cache/cookbooks/rvm/recipes/system.rb:20:in `from_file'

  Relevant File Content:
  ----------------------
  /var/chef/cache/cookbooks/rvm/recipes/system_install.rb:

   27:      gid        node['rvm']['group_id']
   28:      action     :nothing
   29:    end
   30:    g.run_action(:create)
   31:  end
   32:
   33>>  key_server = node['rvm']['gpg']['keyserver'] || "hkp://keys.gnupg.net"
   34: home_dir = "#{node['rvm']['gpg']['homedir'] || '~'}/.gnupg"
   35:
   36:  execute 'Adding gpg key' do
   37:    command "`which gpg2 || which gpg` --keyserver #{key_server} --homedir #{home_dir} --recv-keys #{node['rvm']['gpg_key']}"
   38:    only_if 'which gpg2 || which gpg'
   39:    not_if { node['rvm']['gpg_key'].empty? }
   40:  end
   41:
   42:  rvm_installation("root")
```
