### PR TITLE
Fix the chef_gem deprecation at compile time

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,6 +21,7 @@
 chef_gem 'rvm' do
   action :install
   version '>= 1.11.3.6'
+  compile_time false if respond_to?(:compile_time)
 end
 require 'rvm'
 


### PR DESCRIPTION
Fixes the chef_gem deprecation messages at compile time for Chef Client prior to 12.1.0 described at [https://www.chef.io/blog/2015/03/03/chef-12-1-0-released/](url)
