### PR TITLE
#350 SLES 12+ installed libreadline6 by default

### DIFF
--- a/providers/ruby.rb
+++ b/providers/ruby.rb
@@ -137,7 +137,9 @@ def install_ruby_dependencies(rubie)
       when "suse"
         pkgs = %w{ gcc-c++ patch zlib zlib-devel libffi-devel
                    sqlite3-devel libxml2-devel libxslt-devel }
-        if node['platform_version'].to_f >= 11.0
+        if node['platform_version'].to_f >= 12.0
+          pkgs += %w{ libreadline6 readline-devel libopenssl-devel }
+        elsif node['platform_version'].to_f >= 11.0 && node['platform_version'].to_f < 12.0
           pkgs += %w{ libreadline5 readline-devel libopenssl-devel }
         else
           pkgs += %w{ readline readline-devel openssl-devel }


### PR DESCRIPTION
since from SLES 12.0 the system is installed libreadline6 by default. So the cookbook will fail when install the old version libreadline5. Adding new logic to handle for SLES 12.0 +
if node['platform_version'].to_f >= 11.0
          pkgs += %w{ libreadline5 readline-devel libopenssl-devel }