### PR TITLE
Do not touch the key server if the GPG key is already installed

### DIFF
--- a/recipes/system_install.rb
+++ b/recipes/system_install.rb
@@ -35,8 +35,13 @@ home_dir = "#{node['rvm']['gpg']['homedir'] || '~'}/.gnupg"
 
 execute 'Adding gpg key' do
   command "`which gpg2 || which gpg` --keyserver #{key_server} --homedir #{home_dir} --recv-keys #{node['rvm']['gpg_key']}"
-  only_if 'which gpg2 || which gpg'
-  not_if { node['rvm']['gpg_key'].empty? }
+  retries 3
+  retry_delay 5
+  not_if do
+    node['rvm']['gpg_key'].empty? or
+      (gpg = `which gpg2 || which gpg`.strip).empty? or
+        system("#{gpg} --list-keys #{node['rvm']['gpg_key']} > /dev/null")
+  end
 end
 
 rvm_installation("root")


### PR DESCRIPTION
Maintaining a quite large cluster and this place often causes failures – either keyserver doesn't respond or takes too long to respond. We can avoid touching the remote server if the key is already there.